### PR TITLE
added cookie path

### DIFF
--- a/charts/datalayer-jupyter/templates/ingress.yaml
+++ b/charts/datalayer-jupyter/templates/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: '172800'
     nginx.ingress.kubernetes.io/session-cookie-samesite: None
     nginx.ingress.kubernetes.io/session-cookie-name: jupyter-affinity
+    nginx.ingress.kubernetes.io/session-cookie-path: "/"
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/enable-owasp-core-rules: 'true'
     # FIXME what is the best way to parametrize this - full url or composition?


### PR DESCRIPTION
Adding because I see a lot of these messages in the controller logs. Would like to eliminate it as a possibility. 

![image](https://github.com/user-attachments/assets/450c2495-7765-4a2d-8378-8b8e1057f922)
