### PR TITLE
Added toleration support for iam operator jupyter

### DIFF
--- a/charts/datalayer-iam/templates/deployment.yaml
+++ b/charts/datalayer-iam/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- with .Values.iam.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.iam.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         - name: reg-creds
       containers:

--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -16,6 +16,22 @@ tests:
                       operator: In
                       values:
                       - "true"
+  - it: "test tolerations"
+    set:
+      iam.tolerations:
+        - key: "key1"
+          operator: "Equal"
+          value: "value1"
+          effect: "NoSchedule"
+    asserts:
+      - isSubset:
+          path: spec.template.spec
+          content:
+            tolerations:
+              - key: "key1"
+                operator: "Equal"
+                value: "value1"
+                effect: "NoSchedule"
   - it: "test environment variables"
     asserts:
       - isSubset:

--- a/charts/datalayer-jupyter/templates/deployment.yaml
+++ b/charts/datalayer-jupyter/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- with .Values.jupyter.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.jupyter.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
             - name: reg-creds
       containers:

--- a/charts/datalayer-jupyter/tests/deployment_test.yaml
+++ b/charts/datalayer-jupyter/tests/deployment_test.yaml
@@ -16,6 +16,22 @@ tests:
                       operator: In
                       values:
                       - "true"
+  - it: "test tolerations"
+    set:
+      jupyter.tolerations:
+        - key: "key1"
+          operator: "Equal"
+          value: "value1"
+          effect: "NoSchedule"
+    asserts:
+      - isSubset:
+          path: spec.template.spec
+          content:
+            tolerations:
+              - key: "key1"
+                operator: "Equal"
+                value: "value1"
+                effect: "NoSchedule"
   - it: "test environment variables"
     asserts:
       - isSubset:

--- a/charts/datalayer-operator/templates/deployment.yaml
+++ b/charts/datalayer-operator/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- with .Values.operator.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         - name: reg-creds
       containers:

--- a/charts/datalayer-operator/tests/deployment_test.yaml
+++ b/charts/datalayer-operator/tests/deployment_test.yaml
@@ -16,6 +16,22 @@ tests:
                       operator: In
                       values:
                       - "true"
+  - it: "test tolerations"
+    set:
+      operator.tolerations:
+        - key: "key1"
+          operator: "Equal"
+          value: "value1"
+          effect: "NoSchedule"
+    asserts:
+      - isSubset:
+          path: spec.template.spec
+          content:
+            tolerations:
+              - key: "key1"
+                operator: "Equal"
+                value: "value1"
+                effect: "NoSchedule"
   - it: "test environment variables"
     asserts:
       - isSubset:


### PR DESCRIPTION
At Anaconda, we have deployed the datalayer stack into a shared tenant cluster and are using karpenter to manage our various nodepools. Because the datalayer nodepool doesn't currently specify any taints on the nodes that come up, pods from other services are able to be scheduled on it and we are now hitting some limits. 

By introducing tolerations here, I will be able to introduce taints to datalayer nodes in our cluster and simultaneously make datalayer pods immune to its effects thereby only allowing datalayer pods to be schedulable on the nodes. 

k8s doc for taints/tolerations: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
