### PR TITLE
Add values for datashim charts

### DIFF
--- a/charts/datalayer-datashim/README.md
+++ b/charts/datalayer-datashim/README.md
@@ -1,0 +1,5 @@
+[![Datalayer](https://assets.datalayer.tech/datalayer-25.svg)](https://datalayer.io)
+
+# Datalayer Datashim Helm Chart
+
+See [Datashim](https://github.com/datashim-io/datashim) for more information.

--- a/charts/datalayer-datashim/values-any.yaml
+++ b/charts/datalayer-datashim/values-any.yaml
@@ -1,0 +1,77 @@
+global:
+  dockerRegistrySecret: "" # leave empty if public repo
+  baseRepo: "quay.io/datashim-io"
+  arch: "amd64"
+  type: "k8s"
+  namespaceYaml: true
+  # affinity configuration for Datashim deployments.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: role.datalayer.io/system
+                operator: In
+                values:
+                  - "true"
+  sidecars:
+    kubeletPath: "/var/lib/kubelet"
+    baseRepo: "k8s.gcr.io/sig-storage"
+    images:
+      externalAttacher:
+        image: "csi-attacher"
+        tag: "v3.3.0"
+      nodeDriverRegistrar:
+        image: "csi-node-driver-registrar"
+        tag: "v2.3.0"
+      externalProvisioner:
+        image: "csi-provisioner"
+        tag: "v2.2.2"
+
+csi-nfs-chart:
+  # baseRepo: "anotherrepo"
+  # dockerRegistrySecret: "anothersecret"
+  enabled: false
+  csinfs:
+    image: "csi-nfs"
+    tag: "latest"
+  sidecars: {} # in case you want to force override regardless of the csi-nfs-chart/values.yaml
+  affinity: {}
+
+csi-s3-chart:
+  # baseRepo: "anotherrepo"
+  # dockerRegistrySecret: "anothersecret"
+  # mounter: "goofys"
+  enabled: true
+  csis3:
+    image: "csi-s3"
+    tag: "latest"
+  sidecars: {} # in case you want to force override regardless of the csi-s3-chart/values.yaml
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: role.datalayer.io/jupyter
+                operator: In
+                values:
+                  - "true"
+
+csi-h3-chart:
+  #  baseRepo: "carvicsforth"
+  ## dockerRegistrySecret: "anothersecret"
+  enabled: false
+  csih3:
+    image: "csi-h3"
+    tag: "v1.2.0"
+  sidecars: {}
+
+dataset-operator-chart:
+  #  baseRepo: "quay.io/datashim"
+  # dockerRegistrySecret: "anothersecret"
+  generatekeys:
+    image: "generate-keys"
+    tag: "latest"
+  datasetoperator:
+    image: "dataset-operator"
+    tag: "latest"


### PR DESCRIPTION
This removes the csi for nfs (not used)

The affinity for the daemonset does not work as it requires a release of the helm charts.