### PR TITLE
chore: share name for the azure shared storage

### DIFF
--- a/charts/datalayer-jupyter/Chart.yaml
+++ b/charts/datalayer-jupyter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datalayer Jupyter
 name: datalayer-jupyter
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.0.3
 home: https://datalayer.tech
 sources:

--- a/charts/datalayer-jupyter/README.md
+++ b/charts/datalayer-jupyter/README.md
@@ -4,7 +4,7 @@
 
 Datalayer Jupyter
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: 1.0.3](https://img.shields.io/badge/AppVersion-1.0.3-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 1.0.3](https://img.shields.io/badge/AppVersion-1.0.3-informational?style=flat-square)
 
 ## Documentation
 

--- a/charts/datalayer-jupyter/templates/serviceaccount.yaml
+++ b/charts/datalayer-jupyter/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: datalayer-jupyter
-  namespace: datalayer-api
+  namespace: {{ .Release.Namespace }}

--- a/charts/datalayer-shared-filesystem/README.md
+++ b/charts/datalayer-shared-filesystem/README.md
@@ -14,6 +14,7 @@ For full documentation please checkout [Datalayer Tech](https://datalayer.tech/d
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| sharedStorage.shareName | string | `"shared-storage"` | Specify Azure file share name (applicable for storageProvider being 'azure'). Existing or new Azure file share name. If empty, driver generates an Azure file share name. |
 | sharedStorage.sharedFsPVC | string | `"shared-fs-pvc"` |  |
 | sharedStorage.storageClassName | string | `nil` | Storage class to use If not specified the default value will be inferred from the provider. |
 | sharedStorage.storageOwner.gid | string | `"100"` |  |

--- a/charts/datalayer-shared-filesystem/templates/storage-class.yaml
+++ b/charts/datalayer-shared-filesystem/templates/storage-class.yaml
@@ -6,6 +6,7 @@ metadata:
 provisioner: file.csi.azure.com
 allowVolumeExpansion: true
 parameters:
+  shareName: {{ .Values.sharedStorage.shareName }}
   skuName: Premium_LRS
   protocol: nfs
 {{ end }}

--- a/charts/datalayer-shared-filesystem/values.yaml
+++ b/charts/datalayer-shared-filesystem/values.yaml
@@ -1,4 +1,6 @@
 sharedStorage:
+  # sharedStorage.shareName -- Specify Azure file share name (applicable for storageProvider being 'azure'). Existing or new Azure file share name. If empty, driver generates an Azure file share name.
+  shareName: shared-storage
   sharedFsPVC: shared-fs-pvc
   # sharedStorage.storageProvider -- Will set automatically value depending on the storage provider.
   # Supported value are: "azure" or "ceph"


### PR DESCRIPTION
Another option would have been to also specify the name for the `storageAccount`, but from https://learn.microsoft.com/en-us/azure/aks/azure-csi-files-storage-provision, the storage account must already exist if the name is specified.

We are thus only specifying the `shareName`

```
When a specific storage account name is not provided, the driver will look for a suitable storage account that matches the account settings within the same resource group. If it fails to find a matching storage account, it will create a new one. However, if a storage account name is specified, the storage account must already exist.
```