### PR TITLE
Helm chart update for env values

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.head_ref }}
-          repository: ${{ github.repositoryUrl }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Get changed files

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.head_ref }}
+          repository: ${{ github.repositoryUrl }}
           fetch-depth: 0
 
       - name: Get changed files

--- a/charts/datalayer-iam/Chart.yaml
+++ b/charts/datalayer-iam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datalayer IAM
 name: datalayer-iam
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.0.4
 home: https://datalayer.tech
 sources:

--- a/charts/datalayer-iam/templates/deployment.yaml
+++ b/charts/datalayer-iam/templates/deployment.yaml
@@ -36,15 +36,15 @@ spec:
           ports:
             - containerPort: {{ .Values.iam.port }}
               protocol: TCP
-          {{- if or .Values.iam.env .Values.iam.envValueFrom }}
+          {{- if .Values.iam.env }}
           env:
-            {{- range $key, $value := .Values.iam.envValueFrom }}
-            - name: {{ $key }}
-              valueFrom: {{- $value | toYaml | nindent 16 }}
-            {{- end }}
             {{- range $key, $value := .Values.iam.env }}
             - name: {{ $key }}
+              {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
+              {{- else }}
+              valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- with .Values.iam.resources }}

--- a/charts/datalayer-iam/templates/deployment.yaml
+++ b/charts/datalayer-iam/templates/deployment.yaml
@@ -42,8 +42,10 @@ spec:
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
-              {{- else }}
+              {{- else if kindIs "map" $value }}
               valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- else }}
+              {{- fail "Env value must be either string or map with key secretKeyRef or configMapKeyRef" }}
               {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -38,16 +38,6 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
-              - name: DATALAYER_SOLR_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: solr-basic-auth
-              - name: DATALAYER_SOLR_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: openfga
               - name: DATALAYER_CDN_URL
@@ -94,6 +84,16 @@ tests:
                 value: prod
               - name: DATALAYER_RUN_URL
                 value: ""
+              - name: DATALAYER_SOLR_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+                    name: solr-basic-auth
+              - name: DATALAYER_SOLR_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+                    name: solr-basic-auth
               - name: DATALAYER_SMTP_HOST
                 value: ""
               - name: DATALAYER_SMTP_PASSWORD

--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -38,6 +38,16 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
+              - name: DATALAYER_SOLR_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+                    name: solr-basic-auth
+              - name: DATALAYER_SOLR_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: openfga
               - name: DATALAYER_CDN_URL

--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -38,16 +38,6 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
-              - name: DATALAYER_SOLR_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: solr-basic-auth
-              - name: DATALAYER_SOLR_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: openfga
               - name: DATALAYER_CDN_URL

--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -84,6 +84,14 @@ tests:
                 value: prod
               - name: DATALAYER_RUN_URL
                 value: ""
+              - name: DATALAYER_SMTP_HOST
+                value: ""
+              - name: DATALAYER_SMTP_PASSWORD
+                value: ""
+              - name: DATALAYER_SMTP_PORT
+                value: "0"
+              - name: DATALAYER_SMTP_USERNAME
+                value: ""
               - name: DATALAYER_SOLR_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -94,14 +102,6 @@ tests:
                   secretKeyRef:
                     key: username
                     name: solr-basic-auth
-              - name: DATALAYER_SMTP_HOST
-                value: ""
-              - name: DATALAYER_SMTP_PASSWORD
-                value: ""
-              - name: DATALAYER_SMTP_PORT
-                value: "0"
-              - name: DATALAYER_SMTP_USERNAME
-                value: ""
               - name: DATALAYER_SOLR_ZK_HOST
                 value: solr-datalayer-solrcloud-zookeeper-headless.datalayer-solr.svc.cluster.local
               - name: DATALAYER_STRIPE_API_KEY

--- a/charts/datalayer-iam/values.yaml
+++ b/charts/datalayer-iam/values.yaml
@@ -16,7 +16,7 @@ iam:
             operator: In
             values:
             - "true"
-  envValueFrom:
+  env:
     DATALAYER_SOLR_USERNAME:
       secretKeyRef:
         name: solr-basic-auth
@@ -25,7 +25,6 @@ iam:
       secretKeyRef:
         name: solr-basic-auth
         key: password
-  env:
     DATALAYER_AUTHZ_ENGINE: "openfga"
     DATALAYER_CDN_URL: ""
     DATALAYER_CREDITS_PROVIDER: ""

--- a/charts/datalayer-jupyter/Chart.yaml
+++ b/charts/datalayer-jupyter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datalayer Jupyter
 name: datalayer-jupyter
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.0.3
 home: https://datalayer.tech
 sources:

--- a/charts/datalayer-jupyter/templates/deployment.yaml
+++ b/charts/datalayer-jupyter/templates/deployment.yaml
@@ -43,8 +43,10 @@ spec:
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
-              {{- else }}
+              {{- else if kindIs "map" $value }}
               valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- else }}
+              {{- fail "Env value must be either string or map with key secretKeyRef or configMapKeyRef" }}
               {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/datalayer-jupyter/templates/deployment.yaml
+++ b/charts/datalayer-jupyter/templates/deployment.yaml
@@ -37,15 +37,15 @@ spec:
           ports:
             - containerPort: {{ .Values.jupyter.port }}
               protocol: TCP
-          {{- if or .Values.jupyter.env .Values.jupyter.envValueFrom }}
+          {{- if .Values.jupyter.env }}
           env:
-            {{- range $key, $value := .Values.jupyter.envValueFrom }}
-            - name: {{ $key }}
-              valueFrom: {{- $value | toYaml | nindent 16 }}
-            {{- end }}
             {{- range $key, $value := .Values.jupyter.env }}
             - name: {{ $key }}
+              {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
+              {{- else }}
+              valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- with .Values.jupyter.resources }}

--- a/charts/datalayer-jupyter/tests/deployment_test.yaml
+++ b/charts/datalayer-jupyter/tests/deployment_test.yaml
@@ -38,16 +38,6 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
-              - name: DATALAYER_SOLR_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: solr-basic-auth
-              - name: DATALAYER_SOLR_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: ""
               - name: DATALAYER_CDN_URL

--- a/charts/datalayer-jupyter/tests/deployment_test.yaml
+++ b/charts/datalayer-jupyter/tests/deployment_test.yaml
@@ -38,16 +38,6 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
-              - name: DATALAYER_SOLR_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: solr-basic-auth
-              - name: DATALAYER_SOLR_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: ""
               - name: DATALAYER_CDN_URL
@@ -78,6 +68,16 @@ tests:
                 value: prod
               - name: DATALAYER_RUN_URL
                 value: ""
+              - name: DATALAYER_SOLR_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+                    name: solr-basic-auth
+              - name: DATALAYER_SOLR_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+                    name: solr-basic-auth
               - name: DATALAYER_SOLR_ZK_HOST
                 value: solr-datalayer-solrcloud-zookeeper-headless.datalayer-solr.svc.cluster.local
               - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT

--- a/charts/datalayer-jupyter/tests/deployment_test.yaml
+++ b/charts/datalayer-jupyter/tests/deployment_test.yaml
@@ -38,6 +38,16 @@ tests:
           path: spec.template.spec.containers[0]
           content:
             env:
+              - name: DATALAYER_SOLR_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+                    name: solr-basic-auth
+              - name: DATALAYER_SOLR_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+                    name: solr-basic-auth
               - name: DATALAYER_AUTHZ_ENGINE
                 value: ""
               - name: DATALAYER_CDN_URL

--- a/charts/datalayer-jupyter/values.yaml
+++ b/charts/datalayer-jupyter/values.yaml
@@ -16,7 +16,7 @@ jupyter:
             operator: In
             values:
             - "true"
-  envValueFrom:
+  env:
     DATALAYER_SOLR_USERNAME:
       secretKeyRef:
         name: solr-basic-auth
@@ -25,7 +25,6 @@ jupyter:
       secretKeyRef:
         name: solr-basic-auth
         key: password
-  env:
     DATALAYER_AUTHZ_ENGINE: ""
     DATALAYER_CDN_URL: ""
     DATALAYER_JWT_ALGORITHM: ""

--- a/charts/datalayer-operator/Chart.yaml
+++ b/charts/datalayer-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datalayer Operator
 name: datalayer-operator
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.0.7
 home: https://datalayer.tech
 sources:

--- a/charts/datalayer-operator/templates/deployment.yaml
+++ b/charts/datalayer-operator/templates/deployment.yaml
@@ -41,19 +41,19 @@ spec:
           ports:
             - containerPort: {{ .Values.operator.port }}
               protocol: TCP
-          {{- if or .Values.operator.sharedFsPVC .Values.operator.env .Values.operator.envValueFrom }}
+          {{- if or .Values.operator.sharedFsPVC .Values.operator.env }}
           env:
             {{- if .Values.operator.sharedFsPVC }}
             - name: 'DATALAYER_USERS_VOLUME_CLAIM_NAME'
               value: {{ .Values.operator.sharedFsPVC }}
             {{- end }}
-            {{- range $key, $value := .Values.operator.envValueFrom }}
-            - name: {{ $key }}
-              valueFrom: {{- $value | toYaml | nindent 16 }}
-            {{- end }}
             {{- range $key, $value := .Values.operator.env }}
             - name: {{ $key }}
+              {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
+              {{- else }}
+              valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- end }}
             {{- end }}
           {{- end }}
           readinessProbe:

--- a/charts/datalayer-operator/templates/deployment.yaml
+++ b/charts/datalayer-operator/templates/deployment.yaml
@@ -51,8 +51,10 @@ spec:
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
-              {{- else }}
+              {{- else if kindIs "map" $value }}
               valueFrom: {{- $value | toYaml | nindent 16}}
+              {{- else }}
+              {{- fail "Env value must be either string or map with key secretKeyRef or configMapKeyRef" }}
               {{- end }}
             {{- end }}
           {{- end }}


### PR DESCRIPTION
This update merges the envValueFrom functionality into the `env` prefix to avoid conflict with default values. This can be seen in Argo when it tries to resolve a difference.

![image](https://github.com/user-attachments/assets/9377d8c9-52d1-4d2e-9de7-1c885d03b703)
