### PR TITLE
feat(operator): implement secure RBAC configuration

### DIFF
--- a/charts/datalayer-iam/tests/deployment_test.yaml
+++ b/charts/datalayer-iam/tests/deployment_test.yaml
@@ -138,7 +138,7 @@ tests:
                 value: ""
               - name: OTEL_SDK_DISABLED
                 value: "false"
-            image: datalayer/iam:1.0.17
+            image: datalayer/iam:1.0.19
             imagePullPolicy: Always
             name: iam
             ports:

--- a/charts/datalayer-operator/Chart.yaml
+++ b/charts/datalayer-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Datalayer Operator
 name: datalayer-operator
-version: 1.0.16
+version: 1.0.17
 appVersion: 1.0.19
 home: https://datalayer.tech
 sources:

--- a/charts/datalayer-operator/README.md
+++ b/charts/datalayer-operator/README.md
@@ -4,7 +4,26 @@
 
 Datalayer Operator
 
-![Version: 1.0.16](https://img.shields.io/badge/Version-1.0.16-informational?style=flat-square) ![AppVersion: 1.0.19](https://img.shields.io/badge/AppVersion-1.0.19-informational?style=flat-square)
+![Version: 1.0.17](https://img.shields.io/badge/Version-1.0.17-informational?style=flat-square) ![AppVersion: 1.0.19](https://img.shields.io/badge/AppVersion-1.0.19-informational?style=flat-square)
+
+## Security
+
+This Helm chart implements secure RBAC (Role-Based Access Control) practices:
+
+- **Dedicated ServiceAccount**: Uses a dedicated `datalayer-operator-sa` ServiceAccount instead of the default ServiceAccount, following CIS Kubernetes Benchmark 5.1.5
+- **Restricted Permissions**: Uses a custom ClusterRole with minimal required permissions instead of cluster-admin, following CIS Kubernetes Benchmark 5.1.1
+- **Least Privilege**: Grants only the necessary permissions for managing Jupyter workloads and custom resources
+
+### RBAC Configuration
+
+The operator requires the following permissions:
+- **Core resources**: pods, services, configmaps, secrets, persistentvolumeclaims, events
+- **Apps resources**: deployments, statefulsets, daemonsets, replicasets  
+- **Networking**: ingresses, networkpolicies
+- **Custom resources**: jupyterpools, jupyter-contents, jupyter-environments
+- **CRD management**: customresourcedefinitions
+- **Limited RBAC**: roles, rolebindings (for namespace-scoped permissions)
+- **Read-only access**: namespaces, nodes (for discovery and scheduling)
 
 ## Documentation
 
@@ -18,6 +37,8 @@ For full documentation please checkout [Datalayer Tech](https://datalayer.tech).
 | operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"In"` |  |
 | operator.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0] | string | `"true"` |  |
 | operator.crds | bool | `true` |  |
+| operator.rbac.create | bool | `true` | Create RBAC resources (ServiceAccount, ClusterRole, ClusterRoleBinding) |
+| operator.rbac.serviceAccountName | string | `"datalayer-operator-sa"` | Name of the ServiceAccount to create |
 | operator.env.AWS_ACCESS_KEY_ID | string | `""` |  |
 | operator.env.AWS_DEFAULT_REGION | string | `""` |  |
 | operator.env.AWS_SECRET_ACCESS_KEY | string | `""` |  |

--- a/charts/datalayer-operator/templates/deployment.yaml
+++ b/charts/datalayer-operator/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         karpenter.sh/do-not-disrupt: "true"      
     spec:
+      serviceAccountName: {{ .Values.operator.rbac.serviceAccountName }}
       terminationGracePeriodSeconds: 0
       {{- with .Values.operator.affinity }}
       affinity: {{- toYaml . | nindent 8 }}

--- a/charts/datalayer-operator/templates/operator-clusterrole.yaml
+++ b/charts/datalayer-operator/templates/operator-clusterrole.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.operator.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datalayer-operator-role
+  labels:
+    k8s-app: datalayer-operator
+    app: {{ template "operator.app-name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+# Core resources needed for managing Jupyter workloads
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+
+# Apps resources for managing deployments, statefulsets, etc.
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Networking resources for ingress management
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "networkpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Custom Resource Definitions management
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Datalayer custom resources
+- apiGroups: ["datalayer.io"]
+  resources: ["jupyterpools", "jupyter-contents", "jupyter-environments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# RBAC resources for managing service accounts and role bindings in specific namespaces
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Read-only access to namespaces for discovering available namespaces
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+
+# Read-only access to nodes for scheduling decisions
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+
+# Metrics access for monitoring
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+{{- end }}

--- a/charts/datalayer-operator/templates/operator-clusterrole.yaml
+++ b/charts/datalayer-operator/templates/operator-clusterrole.yaml
@@ -40,6 +40,11 @@ rules:
   resources: ["ingresses", "networkpolicies"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
+# Traefik ingress resources
+- apiGroups: ["traefik.io"]
+  resources: ["ingressroutes", "ingressroutetcps", "ingressrouteudps", "middlewares"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
 # Custom Resource Definitions management
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]

--- a/charts/datalayer-operator/templates/operator-clusterrolebinding.yaml
+++ b/charts/datalayer-operator/templates/operator-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.operator.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datalayer-operator-binding
+  labels:
+    k8s-app: datalayer-operator
+    app: {{ template "operator.app-name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datalayer-operator-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.operator.rbac.serviceAccountName }}
+  namespace: {{ default .Values.operator.namespace .Release.Namespace }}
+{{- end }}

--- a/charts/datalayer-operator/templates/operator-serviceaccount.yaml
+++ b/charts/datalayer-operator/templates/operator-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.operator.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.operator.rbac.serviceAccountName }}
+  namespace: {{ default .Values.operator.namespace .Release.Namespace }}
+  labels:
+    k8s-app: datalayer-operator
+    app: {{ template "operator.app-name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+# Allow API credentials mounting for operator functionality
+automountServiceAccountToken: true
+{{- end }}

--- a/charts/datalayer-operator/templates/roles.yaml
+++ b/charts/datalayer-operator/templates/roles.yaml
@@ -1,18 +1,8 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: datalayer-operator
-  labels:
-    k8s-app: datalayer-operator
-    app: {{ template "operator.app-name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: {{ default .Values.operator.namespace .Release.Namespace }}
+# This file has been replaced with secure RBAC configuration.
+# The new configuration uses:
+# 1. datalayer-operator-sa ServiceAccount (defined in operator-serviceaccount.yaml)
+# 2. datalayer-operator-role ClusterRole with restricted permissions (defined in operator-clusterrole.yaml) 
+# 3. datalayer-operator-binding ClusterRoleBinding (defined in operator-clusterrolebinding.yaml)
+#
+# This replaces the insecure binding of the 'default' ServiceAccount to 'cluster-admin'
+# which violated CIS Kubernetes Benchmarks 5.1.1 and 5.1.5

--- a/charts/datalayer-operator/tests/deployment_test.yaml
+++ b/charts/datalayer-operator/tests/deployment_test.yaml
@@ -64,14 +64,14 @@ tests:
                 value: datalayer-kafka-kafka-bootstrap.datalayer-kafka.svc.cluster.local:9092
               - name: DATALAYER_KAFKA_USERNAME
                 value: ""
-              - name: DATALAYER_RUNTIMES_RUN_HOOKS
-                value: "false"
               - name: DATALAYER_OPERATOR_API_KEY
                 value: ""
               - name: DATALAYER_PUB_SUB_ENGINE
                 value: kafka
               - name: DATALAYER_PULSAR_URL
                 value: pulsar://datalayer-pulsar-broker.datalayer-pulsar.svc.cluster.local:6650
+              - name: DATALAYER_RUNTIMES_RUN_HOOKS
+                value: "false"
               - name: DATALAYER_RUN_URL
                 value: ""
               - name: DATALAYER_VAULT_TOKEN

--- a/charts/datalayer-operator/tests/roles_test.yaml
+++ b/charts/datalayer-operator/tests/roles_test.yaml
@@ -1,11 +1,43 @@
-suite: test roles
+suite: test secure rbac configuration
 templates:
-  - templates/roles.yaml
+  - templates/operator-serviceaccount.yaml
+  - templates/operator-clusterrole.yaml
+  - templates/operator-clusterrolebinding.yaml
 tests:
-  - it: "test ClusterRoleBinding subjects"
+  - it: "test ServiceAccount creation"
+    template: templates/operator-serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: datalayer-operator-sa
+      - equal:
+          path: kind
+          value: ServiceAccount
+
+  - it: "test ClusterRole has restricted permissions"
+    template: templates/operator-clusterrole.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: datalayer-operator-role
+      - equal:
+          path: kind
+          value: ClusterRole
+
+  - it: "test ClusterRoleBinding uses secure ServiceAccount"
+    template: templates/operator-clusterrolebinding.yaml
     release:
       namespace: default
     asserts:
-      - equal: 
+      - equal:
+          path: subjects[0].name
+          value: datalayer-operator-sa
+      - equal:
           path: subjects[0].namespace
           value: default
+      - equal:
+          path: roleRef.name
+          value: datalayer-operator-role
+      - notEqual:
+          path: roleRef.name
+          value: cluster-admin

--- a/charts/datalayer-operator/values.yaml
+++ b/charts/datalayer-operator/values.yaml
@@ -1,4 +1,10 @@
 operator:
+  # RBAC Configuration
+  rbac:
+    # Create RBAC resources (ServiceAccount, ClusterRole, ClusterRoleBinding)
+    create: true
+    # Name of the ServiceAccount to create
+    serviceAccountName: "datalayer-operator-sa"
   image: datalayer/operator:1.0.19
   sidecar:
     image: datalayer/whoami:0.0.6


### PR DESCRIPTION
- Replace insecure cluster-admin binding to default ServiceAccount
- Create dedicated datalayer-operator-sa ServiceAccount
- Implement restrictive ClusterRole with minimal required permissions
- Add ClusterRoleBinding using new ServiceAccount
- Update deployment to use new ServiceAccount
- Add configurable RBAC settings in values.yaml
- Update tests to validate secure configuration
- Update README with security documentation
- Bump chart version to 1.0.17

Fixes CIS Kubernetes Benchmarks:
- 5.1.1 (cluster-admin role restriction)
- 5.1.5 (default ServiceAccount usage)

Security improvements:
- Removes cluster-admin permissions that could delete ArgoCD apps
- Prevents privilege escalation via default ServiceAccount
- Follows principle of least privilege
- Maintains operator functionality with minimal permissions